### PR TITLE
fontreport.py: open file for writing bytes, since we are encoding it ourselves to UTF-8

### DIFF
--- a/fontreport/fontreport.py
+++ b/fontreport/fontreport.py
@@ -605,7 +605,7 @@ def main():
       if ext == '.pdf':
         tofile = name + '.tex'
 
-    with open(tofile, 'w') as f:
+    with open(tofile, 'wb') as f:
       f.write(envelope.Report(xetex).encode('utf-8'))
     if ext == '.pdf':
       # Call twice to let longtable package calculate


### PR DESCRIPTION
the output file is currently opened as "text" and in Python 3, text means unicode strings, whereas we are encoding text as UTF-8 bytes.

So in this case, we need to open the file for writing bytes, as we are encoding the text ourselves in the following line.

Fixes #5
